### PR TITLE
fix: build args

### DIFF
--- a/malefic-mutant/src/build/payload/mod.rs
+++ b/malefic-mutant/src/build/payload/mod.rs
@@ -81,7 +81,10 @@ pub fn build_payload(
         if config.ollvm.constenc {
             args.push("-Cllvm-args=-enable-constenc");
         }
-        args.push("-Cdebuginfo=0 -Cstrip=symbols -Cpanic=abort -Copt-level=3");
+        args.push("-Cdebuginfo=0");
+        args.push("-Cstrip=symbols");
+        args.push("-Cpanic=abort");
+        args.push("-Copt-level=3");
 
         if let Some(feats) = features {
             if !feats.is_empty() {


### PR DESCRIPTION
fix: build args for ollvm build
fix this :
 ERROR ✗ error: incorrect value `0 -Cstrip=symbols -Cpanic=abort -Copt-level=3` for codegen option `debuginfo` - either an integer (0, 1, 2), `none`, `line-directives-only`, `line-tables-only`, `limited`, or `full` was expected

https://github.com/askme765cs/malefic/commit/a98030afe4da8d7ea28e38d17d582df5f946cff6